### PR TITLE
add request format to PerimeterX context

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,12 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [1.0.4] - 2017-04-27
+### Fixed
+ - Constants on px_constants
+ - Cookie Validation flow when cookie score was over the configured threshold
+ - Using symbols instead of strings for requests body

--- a/lib/perimeterx/internal/perimeter_x_context.rb
+++ b/lib/perimeterx/internal/perimeter_x_context.rb
@@ -40,6 +40,7 @@ module PxModule
       @context[:user_agent] = req.user_agent ? req.user_agent : ''
       @context[:uri] = px_config[:custom_uri] ? px_config[:custom_uri].call(req)  : req.headers['REQUEST_URI']
       @context[:full_url] = req.original_url
+      @context[:format] = req.format
       @context[:score] = 0
 
       if px_config.key?(:custom_user_ip)

--- a/lib/perimeterx/internal/perimeter_x_context.rb
+++ b/lib/perimeterx/internal/perimeter_x_context.rb
@@ -40,7 +40,7 @@ module PxModule
       @context[:user_agent] = req.user_agent ? req.user_agent : ''
       @context[:uri] = px_config[:custom_uri] ? px_config[:custom_uri].call(req)  : req.headers['REQUEST_URI']
       @context[:full_url] = req.original_url
-      @context[:format] = req.format
+      @context[:format] = req.format.symbol
       @context[:score] = 0
 
       if px_config.key?(:custom_user_ip)

--- a/lib/perimeterx/version.rb
+++ b/lib/perimeterx/version.rb
@@ -1,3 +1,3 @@
 module PxModule
-  VERSION = '1.0.3'
+  VERSION = '1.0.4'
 end


### PR DESCRIPTION
The PerimeterX module and custom callback function are configured on boot, but we don't know until request time whether or not to respond with HTML or JSON. Accordingly, we need access to the expected request format in the callback, and therefore need to pass it through the context.

Expected response format could be partially determined from HTTP headers, but Rails already does its own Mime type negotiation and incorporates the format set on on the route level, etc. Therefore, passing the format determined by Rails seems like the best option.

We use the value in our custom callback handler to determine whether to return a captcha/block page (HTML) or block JSON payload.