### PR TITLE
Committing code changes to support original token

### DIFF
--- a/lib/perimeterx/configuration.rb
+++ b/lib/perimeterx/configuration.rb
@@ -34,7 +34,8 @@ module PxModule
     }
 
     def initialize(params)
-      PX_DEFAULT[:backend_url] = "https://sapi-#{params[:app_id].downcase}.perimeterx.net"
+#      PX_DEFAULT[:backend_url] = "https://sapi-#{params[:app_id].downcase}.perimeterx.net"
+      PX_DEFAULT[:backend_url] = "http://mocksite.local:3000"
       @configuration = PX_DEFAULT.merge(params)
       @configuration[:logger] = PxLogger.new(@configuration[:debug])
     end

--- a/lib/perimeterx/internal/validators/perimeter_x_cookie_validator.rb
+++ b/lib/perimeterx/internal/validators/perimeter_x_cookie_validator.rb
@@ -31,16 +31,14 @@ module PxModule
           elsif px_ctx.context[:px_cookie].to_s =~ /^\d{1,4}$/
             @logger.warn("PerimeterxCookieValidator:[verify]: Mobile SDK Error Received")
             px_ctx.context[:s2s_call_reason] = PxModule::MOBILE_SDK_ERROR_MESSAGE + px_ctx.context[:px_cookie]
-            if px_ctx.context[:headers][PxModule::ORIGINAL_TOKEN_HEADER]
-              token = force_utf8(px_ctx.context[:headers][PxModule::ORIGINAL_TOKEN_HEADER])
-              @logger.warn("the contents of token are #{token}")
+            if px_ctx.context[:headers][PxModule::ORIGINAL_TOKEN_HEADER.downcase.to_sym]
+              token = force_utf8(px_ctx.context[:headers][PxModule::ORIGINAL_TOKEN_HEADER.downcase.to_sym])
               if token.include? ':'
                 exploded_token = token.split(':', 2)
                 cookie_sym = "v#{exploded_token[0]}".to_sym
-                @logger.warn("I made it to here and token version is #{cookie_sym}")
                 px_ctx.context[:px_cookie][cookie_sym] = exploded_token[1]
               else
-                px_ctx.context[:px_cookie] = force_utf8(px_ctx.context[:headers][PxModule::ORIGINAL_TOKEN_HEADER])
+                px_ctx.context[:px_cookie] = force_utf8(px_ctx.context[:headers][PxModule::ORIGINAL_TOKEN_HEADER.downcase.to_sym])
               end
             else
               return false, px_ctx

--- a/lib/perimeterx/internal/validators/perimeter_x_cookie_validator.rb
+++ b/lib/perimeterx/internal/validators/perimeter_x_cookie_validator.rb
@@ -15,6 +15,10 @@ module PxModule
       @logger = px_config[:logger]
     end
 
+    def force_utf8(str)
+      return str.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '')
+    end
+
 
     def verify(px_ctx)
       begin
@@ -24,18 +28,23 @@ module PxModule
             @logger.warn("PerimeterxCookieValidator:[verify]: Empty token value - decryption failed")
             px_ctx.context[:s2s_call_reason] = PxModule::COOKIE_DECRYPTION_FAILED
             return false, px_ctx
-          elsif px_ctx.context[:px_cookie] == "1"
-            @logger.warn("PerimeterxCookieValidator:[verify]: no cookie")
-            px_ctx.context[:s2s_call_reason] = PxModule::NO_COOKIE
-            return false, px_ctx
-          elsif px_ctx.context[:px_cookie] == "2"   # Mobile SDK connection error
-            @logger.warn("PerimeterxCookieValidator:[verify]: mobile sdk connection error")
-            px_ctx.context[:s2s_call_reason] = PxModule::MOBILE_SDK_CONNECTION_ERROR
-            return false, px_ctx
-          elsif px_ctx.context[:px_cookie] == "3"   # Mobile SDK pinning error
-            @logger.warn("PerimeterxCookieValidator:[verify]: mobile sdk pinning error")
-            px_ctx.context[:s2s_call_reason] = PxModule::MOBILE_SDK_PINNING_ERROR
-            return false, px_ctx
+          elsif px_ctx.context[:px_cookie].to_s =~ /^\d{1,4}$/
+            @logger.warn("PerimeterxCookieValidator:[verify]: Mobile SDK Error Received")
+            px_ctx.context[:s2s_call_reason] = PxModule::MOBILE_SDK_ERROR_MESSAGE + px_ctx.context[:px_cookie]
+            if px_ctx.context[:headers][PxModule::ORIGINAL_TOKEN_HEADER]
+              token = force_utf8(px_ctx.context[:headers][PxModule::ORIGINAL_TOKEN_HEADER])
+              @logger.warn("the contents of token are #{token}")
+              if token.include? ':'
+                exploded_token = token.split(':', 2)
+                cookie_sym = "v#{exploded_token[0]}".to_sym
+                @logger.warn("I made it to here and token version is #{cookie_sym}")
+                px_ctx.context[:px_cookie][cookie_sym] = exploded_token[1]
+              else
+                px_ctx.context[:px_cookie] = force_utf8(px_ctx.context[:headers][PxModule::ORIGINAL_TOKEN_HEADER])
+              end
+            else
+              return false, px_ctx
+            end
           end
         elsif px_ctx.context[:px_cookie].empty?
           @logger.warn("PerimeterxCookieValidator:[verify]: no cookie")

--- a/lib/perimeterx/utils/px_constants.rb
+++ b/lib/perimeterx/utils/px_constants.rb
@@ -54,8 +54,10 @@ module PxModule
 
   # Mobile SDK
   TOKEN_HEADER = 'X-PX-AUTHORIZATION'
+  ORIGINAL_TOKEN_HEADER = 'X-PX-ORIGINAL-TOKEN'
   MOBILE_SDK_CONNECTION_ERROR = 'mobile_sdk_connection_error'
   MOBILE_SDK_PINNING_ERROR = 'mobile_sdk_pinning_error'
+  MOBILE_SDK_ERROR_MESSAGE = 'mobile_error_'
 
   # Regular Expressions
   VID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/


### PR DESCRIPTION
: WORKING == mobile_error_# s2s call
: NOT WORKING == evaluating px-original-token when px-auth is an error number